### PR TITLE
Passive visibility changes

### DIFF
--- a/Content.Client/Chameleon/ChameleonSystem.cs
+++ b/Content.Client/Chameleon/ChameleonSystem.cs
@@ -1,4 +1,4 @@
-﻿using Content.Client.Interactable.Components;
+using Content.Client.Interactable.Components;
 using Content.Shared.Chameleon;
 using Content.Shared.Chameleon.Components;
 using Robust.Client.GameObjects;
@@ -18,13 +18,13 @@ public sealed class ChameleonSystem : SharedChameleonSystem
         base.Initialize();
 
         _shader = _protoMan.Index<ShaderPrototype>("Chameleon").InstanceUnique();
-        SubscribeLocalEvent<SharedChameleonComponent, ComponentInit>(OnAdd);
         SubscribeLocalEvent<SharedChameleonComponent, ComponentRemove>(OnRemove);
         SubscribeLocalEvent<SharedChameleonComponent, BeforePostShaderRenderEvent>(OnShaderRender);
     }
 
-    private void OnAdd(EntityUid uid, SharedChameleonComponent component, ComponentInit args)
+    protected override void OnInit(EntityUid uid, SharedChameleonComponent component, ComponentInit args)
     {
+        base.OnInit(uid, component, args);
         if (!TryComp(uid, out SpriteComponent? sprite))
             return;
 
@@ -47,6 +47,7 @@ public sealed class ChameleonSystem : SharedChameleonSystem
         sprite.PostShader = null;
         sprite.GetScreenTexture = false;
         sprite.RaiseShaderEvent = false;
+        sprite.Color = Color.White;
 
         if (component.HadOutline)
             AddComp<InteractionOutlineComponent>(uid);
@@ -62,12 +63,10 @@ public sealed class ChameleonSystem : SharedChameleonSystem
         // unchanged.
         var parentXform = Transform(Transform(uid).ParentUid);
         var reference = args.Viewport.WorldToLocal(parentXform.WorldPosition);
-
+        var visibility = Getvisibility(uid, component);
         _shader.SetParameter("reference", reference);
-        _shader.SetParameter("stealthLevel", component.StealthLevel);
-        args.Sprite.Color = new Color(component.StealthLevel, component.StealthLevel, 1, 1);
-
-        Dirty(component);
+        _shader.SetParameter("visibility", visibility);
+        args.Sprite.Color = new Color(visibility, visibility, 1, 1);
     }
 }
 

--- a/Content.Client/Chameleon/ChameleonSystem.cs
+++ b/Content.Client/Chameleon/ChameleonSystem.cs
@@ -66,6 +66,8 @@ public sealed class ChameleonSystem : SharedChameleonSystem
         var visibility = Getvisibility(uid, component);
         _shader.SetParameter("reference", reference);
         _shader.SetParameter("visibility", visibility);
+
+        visibility = MathF.Max(0, visibility);
         args.Sprite.Color = new Color(visibility, visibility, 1, 1);
     }
 }

--- a/Content.Shared/Chameleon/SharedChameleonSystem.cs
+++ b/Content.Shared/Chameleon/SharedChameleonSystem.cs
@@ -58,6 +58,9 @@ public abstract class SharedChameleonSystem : EntitySystem
 
     private void OnMove(EntityUid uid, SharedChameleonComponent component, ref MoveEvent args)
     {
+        if (args.FromStateHandling)
+            return;
+
         if (args.NewPosition.EntityId != args.OldPosition.EntityId)
             return;
 

--- a/Content.Shared/Chameleon/SharedChameleonSystem.cs
+++ b/Content.Shared/Chameleon/SharedChameleonSystem.cs
@@ -72,10 +72,8 @@ public abstract class SharedChameleonSystem : EntitySystem
 
         if (component.LastUpdated != null)
         {
-            var curTime = _timing.CurTime;
-            var deltaTime = curTime - component.LastUpdated.Value;
-            component.LastVisibility = Math.Clamp(component.LastVisibility + (float) deltaTime.TotalSeconds * component.PassiveVisibilityRate, -1f, 1f);
-            component.LastUpdated = curTime;
+            component.LastVisibility = Getvisibility(uid, component);
+            component.LastUpdated = _timing.CurTime;
         }
 
         component.LastVisibility = Math.Clamp(component.LastVisibility + delta, -1f, 1f);

--- a/Content.Shared/Chameleon/SharedChameleonSystem.cs
+++ b/Content.Shared/Chameleon/SharedChameleonSystem.cs
@@ -1,4 +1,4 @@
-﻿using Content.Shared.Chameleon.Components;
+using Content.Shared.Chameleon.Components;
 using Robust.Shared.GameStates;
 using Robust.Shared.Timing;
 
@@ -6,11 +6,7 @@ namespace Content.Shared.Chameleon;
 
 public abstract class SharedChameleonSystem : EntitySystem
 {
-    /// <summary>
-    /// The maximum threshold of stealth. Should stay -1.
-    /// Helps prevent the component from updating every tick when it doesn't need to anymore.
-    /// </summary>
-    private const float StealthThreshold = -1;
+    [Dependency] private readonly IGameTiming _timing = default!;
 
     public override void Initialize()
     {
@@ -19,28 +15,36 @@ public abstract class SharedChameleonSystem : EntitySystem
         SubscribeLocalEvent<SharedChameleonComponent, ComponentGetState>(OnChameleonGetState);
         SubscribeLocalEvent<SharedChameleonComponent, ComponentHandleState>(OnChameleonHandlesState);
         SubscribeLocalEvent<SharedChameleonComponent, MoveEvent>(OnMove);
+        SubscribeLocalEvent<SharedChameleonComponent, EntityPausedEvent>(OnPaused);
+        SubscribeLocalEvent<SharedChameleonComponent, ComponentInit>(OnInit);
     }
 
-    public override void Update(float frameTime)
+    private void OnPaused(EntityUid uid, SharedChameleonComponent component, EntityPausedEvent args)
     {
-        base.Update(frameTime);
-
-        foreach (var chameleon in EntityQuery<SharedChameleonComponent>())
+        if (args.Paused)
         {
-            //Only update if the current stealth level is above the stealth threshold
-            //This stops it from needlessly updating and calling Dirty once it's hit max stealth
-            if (chameleon.StealthLevel > StealthThreshold)
-            {
-                chameleon.StealthLevel = Math.Clamp(chameleon.StealthLevel - frameTime * chameleon.InvisibilityRate, -1f, 1f);
-
-                Dirty(chameleon);
-            }
+            component.LastVisibility = Getvisibility(uid, component);
+            component.LastUpdated = null;
         }
+        else
+        {
+            component.LastUpdated = _timing.CurTime;
+        }
+
+        Dirty(component);
+    }
+
+    protected virtual void OnInit(EntityUid uid, SharedChameleonComponent component, ComponentInit args)
+    {
+        if (component.LastUpdated != null || Paused(uid))
+            return;
+
+        component.LastUpdated = _timing.CurTime;
     }
 
     private void OnChameleonGetState(EntityUid uid, SharedChameleonComponent component, ref ComponentGetState args)
     {
-        args.State = new ChameleonComponentState(component.StealthLevel);
+        args.State = new ChameleonComponentState(component.LastVisibility, component.LastUpdated);
     }
 
     private void OnChameleonHandlesState(EntityUid uid, SharedChameleonComponent component, ref ComponentHandleState args)
@@ -48,7 +52,8 @@ public abstract class SharedChameleonSystem : EntitySystem
         if (args.Current is not ChameleonComponentState cast)
             return;
 
-        component.StealthLevel = cast.StealthLevel;
+        component.LastVisibility = cast.Visibility;
+        component.LastUpdated = cast.LastUpdated;
     }
 
     private void OnMove(EntityUid uid, SharedChameleonComponent component, ref MoveEvent args)
@@ -56,9 +61,48 @@ public abstract class SharedChameleonSystem : EntitySystem
         if (args.NewPosition.EntityId != args.OldPosition.EntityId)
             return;
 
-        component.StealthLevel += component.VisibilityRate*(args.NewPosition.Position - args.OldPosition.Position).Length;
-        component.StealthLevel = Math.Clamp(component.StealthLevel, -1f, 1f);
+        var delta = component.MovementVisibilityRate * (args.NewPosition.Position - args.OldPosition.Position).Length;
+        AddVisibility(uid, delta, component);
+    }
+
+    public void AddVisibility(EntityUid uid, float delta, SharedChameleonComponent? component = null)
+    {
+        if (delta == 0 || !Resolve(uid, ref component))
+            return;
+
+        if (component.LastUpdated != null)
+        {
+            var curTime = _timing.CurTime;
+            var deltaTime = curTime - component.LastUpdated.Value;
+            component.LastVisibility = Math.Clamp(component.LastVisibility + (float) deltaTime.TotalSeconds * component.PassiveVisibilityRate, -1f, 1f);
+            component.LastUpdated = curTime;
+        }
+
+        component.LastVisibility = Math.Clamp(component.LastVisibility + delta, -1f, 1f);
+        Dirty(component);
+    }
+
+    public void SetVisibility(EntityUid uid, float value, SharedChameleonComponent? component = null)
+    {
+        if (!Resolve(uid, ref component))
+            return;
+
+        component.LastVisibility = value;
+        if (component.LastUpdated != null)
+            component.LastUpdated = _timing.CurTime;
 
         Dirty(component);
+    }
+
+    public float Getvisibility(EntityUid uid, SharedChameleonComponent? component = null)
+    {
+        if (!Resolve(uid, ref component))
+            return 1;
+
+        if (component.LastUpdated == null)
+            return component.LastVisibility;
+
+        var deltaTime = _timing.CurTime - component.LastUpdated.Value;
+        return Math.Clamp(component.LastVisibility + (float) deltaTime.TotalSeconds * component.PassiveVisibilityRate, -1f, 1f);
     }
 }

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/big_boxes.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/big_boxes.yml
@@ -67,8 +67,8 @@
           state: agentbox
           state_open: cardboard_open
     - type: Chameleon
-      invisibilityRate: 0.24
-      visibilityRate: 0.10
+      passiveVisibilityRate: -0.24
+      movementVisibilityRate: 0.10
 
 #For admin spawning only
 - type: entity

--- a/Resources/Textures/Shaders/chameleon.swsl
+++ b/Resources/Textures/Shaders/chameleon.swsl
@@ -1,7 +1,7 @@
 light_mode unshaded;
 
 uniform sampler2D SCREEN_TEXTURE;
-uniform highp float stealthLevel;
+uniform highp float visibility; // number between -1 and 1
 uniform mediump vec2 reference;
 
 const mediump float time_scale = 0.25;
@@ -22,14 +22,13 @@ void fragment() {
     // visualize distortion via:
     // COLOR = vec4(w,w,w,1);
 
-    w *= (3 + stealthLevel * 2);
+    w *= (3 + visibility * 2);
 
     vec4 background = zTextureSpec(SCREEN_TEXTURE, ( FRAGCOORD.xy + vec2(w) ) * SCREEN_PIXEL_SIZE );
 
     float alpha;
-    //-1 and 1 are the current maximums
-    if (stealthLevel>0)
-      alpha = sprite.a * stealthLevel;
+    if (visibility>0)
+      alpha = sprite.a * visibility;
     else
       alpha = 0;
 


### PR DESCRIPTION
- Removes update function and just tracks the time since last updated instead.
- Renames some datafields, 
  - Generally renames `StealthLevel` -> `Visibility`
    - IMO a better name, because a smaller number is less visible & more stealthy
  - Renames the "(in)visbility" rates to "passive" & "movement" rates 
- Adds functions to Add/Set/Get visibility in a way that accounts for the last updated time.